### PR TITLE
add `RUNS_PER_USER` configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dev
 orchestrator-wd-data
 *html
 db.sqlite
+data
+run.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchestrator"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "Asynchronous job orchestrator for managing and routing payloads between services and computing resources with quota tracking"
 authors = ["Rodrigo V. Honorato <rvhonorato@protonmail.com>"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the [BonvinLab](https://bonvinlab.org) at the [Utrecht University](https://uu.nl
 It is closely coupled with [`jobd`](https://github.com/rvhonorato/jobd),
 with more destinations to be added in the future such as:
 
-- [DIRAC interware](https://dirac.readthedocs.io/en/latest/index.html)
+- [DIRAC Interware](https://dirac.readthedocs.io/en/latest/index.html)
 - Educational cloud services
 - SLURM
 
@@ -33,6 +33,75 @@ flowchart LR
     E -->|slurml| H[local HPC]
 ```
 
+## Example deployment
+
+```bash
+docker compose -f deployment/docker_compose.yml --project-directory . up
+```
+
+Create a dummy run script:
+
+```bash
+cat <<EOF > run.sh
+#!/bin/bash
+# Pretend we are calculating something
+sleep $((RANDOM % 3 + 1))m
+# Done!
+echo 'This is a downloadable file.' > output.txt
+EOF
+```
+
+POST it
+
+```bash
+curl -s -X POST http://localhost:5000/upload \
+  -F "file=@run.sh" \
+  -F "user_id=1" \
+  -F "service=generic" | jq
+```
+
+It will return some information:
+
+```json
+{
+  "id": 1,
+  "user_id": 1,
+  "service": "generic",
+  "status": "Queued",
+  "loc": "/opt/data/978e5a14-dc94-46ab-9507-fe0a94d688b8",
+  "dest_id": ""
+}
+```
+
+CHECK the status:
+
+```bash
+$ curl -I http://localhost:5000/download/1
+HTTP/1.1 202 Accepted
+content-length: 0
+date: Mon, 06 Oct 2025 14:10:44 GMT
+```
+
+- `200`, File downloaded successfully
+- `202`, Job not ready,
+- `204`, Job failed or cleaned
+- `404`, Job not found
+- `500`, Internal server error
+
+GET it
+
+```bash
+curl -I http://localhost:5000/download/16 user-limit ✭ ✱
+HTTP/1.1 200 OK
+content-type: application/octet-stream
+content-length: 380
+date: Mon, 06 Oct 2025 14:13:16 GMT
+```
+
+```bash
+curl -o results.zip http://localhost:5000/download/1
+```
+
 ## Implementation
 
 🚧 soon 🚧
@@ -43,4 +112,5 @@ flowchart LR
 
 ## Contact
 
-If you think this project would be useful for your use case or would like to suggest something, please reach out either via issue here or via email. (:
+If you think this project would be useful for your use case or would like to
+suggest something, please reach out either via issue here or via email. (:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ curl -o results.zip http://localhost:5000/download/1
 ### Extra: Submit a large volume to see the queue in action
 
 ```bash
-for i in {1..100}; do
+for i in {1..200}; do
   cat <<EOF > run.sh
 #!/bin/bash
 # Pretend we are calculating something
@@ -119,7 +119,8 @@ EOF
   curl -s -X POST http://localhost:5000/upload \
     -F "file=@run.sh" \
     -F "user_id=1" \
-    -F "service=generic"
+    -F "service=generic" > /dev/null
+  echo "Submitted job $i"
 done
 
 ```

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ curl -o results.zip http://localhost:5000/download/1
 ### Extra: Submit a large volume to see the queue in action
 
 ```bash
-for i in {1..200}; do
+for i in {1..250}; do
   cat <<EOF > run.sh
 #!/bin/bash
 # Pretend we are calculating something
@@ -122,8 +122,10 @@ EOF
     -F "service=generic" > /dev/null
   echo "Submitted job $i"
 done
-
 ```
+
+> On the logs of the `orchestrator` container, you will the jobs being processed
+> in batches
 
 ## Implementation
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,16 @@ flowchart LR
 ## Example deployment
 
 ```bash
-docker compose -f deployment/docker_compose.yml --project-directory . up
+$ docker compose \
+  -f deployment/docker_compose.yml \
+  --project-directory .\
+  up
 ```
 
-Create a dummy run script:
+### Create a dummy run script
 
 ```bash
-cat <<EOF > run.sh
+$ cat <<EOF > run.sh
 #!/bin/bash
 # Pretend we are calculating something
 sleep $((RANDOM % 3 + 1))m
@@ -51,10 +54,10 @@ echo 'This is a downloadable file.' > output.txt
 EOF
 ```
 
-POST it
+### POST it
 
 ```bash
-curl -s -X POST http://localhost:5000/upload \
+$ curl -s -X POST http://localhost:5000/upload \
   -F "file=@run.sh" \
   -F "user_id=1" \
   -F "service=generic" | jq
@@ -73,7 +76,7 @@ It will return some information:
 }
 ```
 
-CHECK the status:
+### CHECK the status
 
 ```bash
 $ curl -I http://localhost:5000/download/1
@@ -88,10 +91,10 @@ date: Mon, 06 Oct 2025 14:10:44 GMT
 - `404`, Job not found
 - `500`, Internal server error
 
-GET it
+### GET it
 
 ```bash
-curl -I http://localhost:5000/download/16 user-limit ✭ ✱
+$ curl -I http://localhost:5000/download/16
 HTTP/1.1 200 OK
 content-type: application/octet-stream
 content-length: 380
@@ -100,6 +103,25 @@ date: Mon, 06 Oct 2025 14:13:16 GMT
 
 ```bash
 curl -o results.zip http://localhost:5000/download/1
+```
+
+### Extra: Submit a large volume to see the queue in action
+
+```bash
+for i in {1..100}; do
+  cat <<EOF > run.sh
+#!/bin/bash
+# Pretend we are calculating something
+sleep \$((RANDOM % 3 + 1))m
+# Done!
+echo 'This is a downloadable file.' > output.txt
+EOF
+  curl -s -X POST http://localhost:5000/upload \
+    -F "file=@run.sh" \
+    -F "user_id=1" \
+    -F "service=generic"
+done
+
 ```
 
 ## Implementation

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ flowchart LR
 $ docker compose \
   -f deployment/docker_compose.yml \
   --project-directory .\
-  up
+  up -d
 ```
 
 ### Create a dummy run script
@@ -112,7 +112,7 @@ for i in {1..250}; do
   cat <<EOF > run.sh
 #!/bin/bash
 # Pretend we are calculating something
-sleep \$((RANDOM % 3 + 1))m
+sleep \$((RANDOM % 36 + 25))
 # Done!
 echo 'This is a downloadable file.' > output.txt
 EOF
@@ -124,8 +124,16 @@ EOF
 done
 ```
 
-> On the logs of the `orchestrator` container, you will the jobs being processed
-> in batches
+See the logs of the `orchestrator` container:
+
+```bash
+  -f deployment/docker_compose.yml \
+  --project-directory .\
+  logs orchestrator --follow
+```
+
+You will see jobs being picked up and sent to `jobd` gradually,
+following the quota defined in the configuration file via `SERVICE_GENERIC_RUNS_PER_USER`
 
 ## Implementation
 

--- a/deployment/docker_compose.yml
+++ b/deployment/docker_compose.yml
@@ -13,9 +13,10 @@ services:
       # Services #==================================================#
       SERVICE_GENERIC_UPLOAD_URL: http://generic:8888/api/upload
       SERVICE_GENERIC_DOWNLOAD_URL: http://generic:8888/api/get
+      SERVICE_GENERIC_RUNS_PER_USER: 5
       #=============================================================#
     ports:
-      - "3000:3000"
+      - "5000:5000"
     volumes:
       - orchestrator-data:/opt/data
     networks:

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -18,6 +18,7 @@ pub struct Service {
     pub name: String,
     pub upload_url: String,
     pub download_url: String,
+    pub runs_per_user: u16,
 }
 
 impl Config {
@@ -40,14 +41,18 @@ impl Config {
                             name: service_name.to_string().to_ascii_lowercase(),
                             upload_url: String::new(),
                             download_url: String::new(),
+                            runs_per_user: u16::MIN,
                         });
 
                     // Assign the corresponding URL based on the type
-                    if service_type == "UPLOAD" {
-                        service.upload_url = value;
-                    } else if service_type == "DOWNLOAD" {
-                        service.download_url = value;
-                    }
+                    match service_type {
+                        "UPLOAD" => service.upload_url = value,
+                        "DOWNLOAD" => service.download_url = value,
+                        "RUNS_PER_USER" => {
+                            service.runs_per_user = value.parse::<u16>().unwrap_or(5)
+                        }
+                        _ => continue, // Skip if it's not a recognized type
+                    };
                 }
             }
         }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -32,7 +32,7 @@ impl Config {
                 let parts: Vec<&str> = key.split('_').collect();
                 if parts.len() >= 3 {
                     let service_name = parts[1]; // Extract the service name from the variable
-                    let service_type = parts[2]; // "UPLOAD" or "DOWNLOAD"
+                    let service_vars = parts[2..].join("_"); // Join the rest for type
 
                     // Use the service name as a key to store the service info
                     let service = services
@@ -44,10 +44,10 @@ impl Config {
                             runs_per_user: u16::MIN,
                         });
 
-                    // Assign the corresponding URL based on the type
-                    match service_type {
-                        "UPLOAD" => service.upload_url = value,
-                        "DOWNLOAD" => service.download_url = value,
+                    // Assign the corresponding vars to the config
+                    match service_vars.as_str() {
+                        "UPLOAD_URL" => service.upload_url = value,
+                        "DOWNLOAD_URL" => service.download_url = value,
                         "RUNS_PER_USER" => {
                             service.runs_per_user = value.parse::<u16>().unwrap_or(5)
                         }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -27,7 +27,10 @@ impl Config {
 
         // Iterate over all environment variables
         for (key, value) in env::vars() {
-            // Look for service environment variables with the pattern SERVICE_<NAME>_UPLOAD_URL and SERVICE_<NAME>_DOWNLOAD_URL
+            // Look for service environment variables with the pattern:
+            // - SERVICE_<NAME>_UPLOAD_URL
+            // - SERVICE_<NAME>_DOWNLOAD_URL
+            // - SERVICE_<NAME>_RUNS_PER_USER
             if key.starts_with("SERVICE_") {
                 let parts: Vec<&str> = key.split('_').collect();
                 if parts.len() >= 3 {
@@ -41,17 +44,15 @@ impl Config {
                             name: service_name.to_string().to_ascii_lowercase(),
                             upload_url: String::new(),
                             download_url: String::new(),
-                            runs_per_user: u16::MIN,
+                            runs_per_user: 5, // by default consider 5 runs per user per service
                         });
 
                     // Assign the corresponding vars to the config
                     match service_vars.as_str() {
                         "UPLOAD_URL" => service.upload_url = value,
                         "DOWNLOAD_URL" => service.download_url = value,
-                        "RUNS_PER_USER" => {
-                            service.runs_per_user = value.parse::<u16>().unwrap_or(5)
-                        }
-                        _ => continue, // Skip if it's not a recognized type
+                        "RUNS_PER_USER" => service.runs_per_user = value.parse::<u16>().unwrap(),
+                        _ => continue,
                     };
                 }
             }

--- a/src/controllers/orchestrator.rs
+++ b/src/controllers/orchestrator.rs
@@ -237,6 +237,7 @@ mod tests {
                 name: String::from("test-service"),
                 upload_url: String::from("http://localhost/upload"),
                 download_url: String::from("http://localhost/download"),
+                runs_per_user: 5,
             },
         )]);
 

--- a/src/models/queue_dao.rs
+++ b/src/models/queue_dao.rs
@@ -1,12 +1,17 @@
 use super::job_dao::Job;
+use crate::config::loader::Config;
 
 #[derive(Debug)]
-pub struct Queue {
+pub struct Queue<'a> {
     pub jobs: Vec<Job>,
+    pub config: &'a Config,
 }
 
-impl Queue {
-    pub fn new() -> Queue {
-        Queue { jobs: Vec::new() }
+impl Queue<'_> {
+    pub fn new(config: &Config) -> Queue {
+        Queue {
+            jobs: Vec::new(),
+            config,
+        }
     }
 }

--- a/src/models/queue_dto.rs
+++ b/src/models/queue_dto.rs
@@ -68,11 +68,11 @@ impl Queue<'_> {
         for row in rows {
             let user_id: i64 = row.get("user_id");
             let service: String = row.get("service");
-            let status: String = row.get("status");
-            info!(
-                "DB Row: user_id={}, service={}, status={}",
-                user_id, service, status
-            );
+            // let status: String = row.get("status");
+            // info!(
+            //     "DB Row: user_id={}, service={}, status={}",
+            //     user_id, service, status
+            // );
 
             // Check what is the limit for this service
             let limit = *service_limits.entry(service.clone()).or_insert_with(|| {
@@ -86,10 +86,10 @@ impl Queue<'_> {
             let submitted = *submitted_counts
                 .get(&(user_id, service.clone()))
                 .unwrap_or(&0);
-            info!(
-                "User: {}, Service: {}, Submitted: {}, Limit: {}",
-                user_id, service, submitted, limit
-            );
+            // info!(
+            //     "User: {}, Service: {}, Submitted: {}, Limit: {}",
+            //     user_id, service, submitted, limit
+            // );
             // Check if this user/service combo can take more jobs
             let key = (user_id, service.clone());
             let user_queue = jobs_by_user_service.entry(key).or_default();

--- a/src/models/queue_dto.rs
+++ b/src/models/queue_dto.rs
@@ -96,13 +96,13 @@ impl Queue<'_> {
             let remaining_slots = (limit - submitted) as usize;
             // if submitted < limit, we can add more jobs, it has not yet reached the limit
             // if user_queue.len() < remaining_slots, we can still add to this user's queue
-            info!(
-                "User: {}, Service: {}, Current Queue Length: {}, Remaining Slots: {}",
-                user_id,
-                service,
-                user_queue.len(),
-                remaining_slots
-            );
+            // info!(
+            //     "User: {}, Service: {}, Current Queue Length: {}, Remaining Slots: {}",
+            //     user_id,
+            //     service,
+            //     user_queue.len(),
+            //     remaining_slots
+            // );
             if submitted < limit && user_queue.len() < remaining_slots {
                 let status: String = row.get("status");
                 let loc: String = row.get("loc");

--- a/src/models/queue_dto.rs
+++ b/src/models/queue_dto.rs
@@ -4,7 +4,6 @@ use super::{queue_dao::Queue, status_dto::Status};
 use crate::models::job_dao::Job;
 use sqlx::{Row, SqlitePool};
 use std::collections::HashMap;
-use tracing::info;
 
 impl Queue<'_> {
     pub async fn list_per_status(

--- a/src/models/queue_dto.rs
+++ b/src/models/queue_dto.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 use super::{queue_dao::Queue, status_dto::Status};
 use crate::models::job_dao::Job;
 use sqlx::{Row, SqlitePool};
+use std::collections::HashMap;
 
-impl Queue {
+impl Queue<'_> {
     pub async fn list_per_status(
         &mut self,
         status: Status,
@@ -33,53 +34,172 @@ impl Queue {
         self.jobs = jobs;
         Ok(())
     }
-    pub async fn load(&mut self, status: Status, pool: &SqlitePool) -> Result<(), sqlx::Error> {
-        //=======================================================================
-        // This query selects jobs with the specified status, ensuring:
-        // 1. Each user has no more than 4 jobs in 'Processing' status
-        // 2. For each user, only up to 4 jobs are selected
-        //
-        // The query uses a Common Table Expression (CTE) to:
-        // - Count processing jobs per user
-        // - Assign a rank to jobs within each user's set of jobs
-        // - Select only jobs where:
-        //   a) The user has fewer than 4 processing jobs
-        //   b) The job is within the first 4 jobs for that user
-        //=======================================================================
-        let rows = sqlx::query(
-            "WITH UserJobCounts AS (
-                SELECT 
-                    j.*, 
-                    (SELECT COUNT(*) FROM jobs 
-                    WHERE user_id = j.user_id AND status = 'submitted') AS submitted_count,
-                    ROW_NUMBER() OVER (PARTITION BY j.user_id ORDER BY j.id) AS user_job_rank
-                FROM jobs j
-                WHERE j.status = ?
-            )
-            SELECT * FROM UserJobCounts
-            WHERE submitted_count < 4 AND user_job_rank <= 4",
+    pub async fn load(&mut self, pool: &SqlitePool) -> Result<(), sqlx::Error> {
+        println!("{:?}", self.config);
+        // ===========================================================================================
+        // Step 1: Get all QUEUED jobs
+        let rows = sqlx::query("SELECT * FROM jobs WHERE status = ?")
+            .bind(Status::Queued.to_string())
+            .fetch_all(pool)
+            .await?;
+
+        // ===========================================================================================
+        // Step 2: Get submitted job counts per user/service
+        let submitted_rows = sqlx::query(
+            "SELECT user_id, service, COUNT(*) as count FROM jobs WHERE status = 'submitted' GROUP BY user_id, service"
         )
-        .bind(status.to_string())
         .fetch_all(pool)
         .await?;
-        //=======================================================================
 
-        let jobs: Vec<Job> = rows
-            .into_iter()
-            .map(|row| {
+        let mut submitted_counts: HashMap<(i64, String), u16> = HashMap::new();
+        for row in submitted_rows {
+            let user_id: i64 = row.get("user_id");
+            let service: String = row.get("service");
+            let count: i64 = row.get("count");
+            submitted_counts.insert((user_id, service), count as u16);
+        }
+
+        // ===========================================================================================
+        // Step 3: Filter jobs according to config limits
+        // `jobs_by_user_service` will hold the jobs to be processed
+        let mut jobs_by_user_service: HashMap<(i64, String), Vec<Job>> = HashMap::new();
+
+        // `service_limits` will cache the limits per service, so we don't have to look them up
+        // multiple times
+        let mut service_limits: HashMap<String, u16> = HashMap::new();
+
+        for row in rows {
+            let user_id: i64 = row.get("user_id");
+            let service: String = row.get("service");
+
+            // Check what is the limit for this service
+            let limit = *service_limits.entry(service.clone()).or_insert_with(|| {
+                self.config
+                    .services
+                    .get(&service)
+                    .map(|s| s.runs_per_user)
+                    .unwrap_or(5) // Default limit if service not found
+            });
+
+            let submitted = *submitted_counts
+                .get(&(user_id, service.clone()))
+                .unwrap_or(&0);
+
+            // Check if this user/service combo can take more jobs
+            let key = (user_id, service.clone());
+            let user_queue = jobs_by_user_service.entry(key).or_default();
+            let remaining_slots = (limit - submitted) as usize;
+
+            // if submitted < limit, we can add more jobs, it has not yet reached the limit
+            // if user_queue.len() < remaining_slots, we can still add to this user's queue
+            if submitted < limit && user_queue.len() < remaining_slots {
                 let status: String = row.get("status");
                 let loc: String = row.get("loc");
-                Job {
+                user_queue.push(Job {
                     id: row.get("id"),
-                    user_id: row.get("user_id"),
-                    service: row.get("service"),
+                    user_id: user_id.try_into().unwrap(),
+                    service: service.clone(),
                     status: Status::from_string(&status),
                     loc: PathBuf::from(loc),
                     dest_id: row.get("dest_id"),
-                }
-            })
-            .collect();
-        self.jobs = jobs;
+                });
+            }
+        }
+        // ===========================================================================================
+        // Step 4: Flatten the jobs_by_user_service into self.jobs
+        self.jobs = jobs_by_user_service.into_values().flatten().collect();
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::loader::{Config, Service};
+    use crate::models::job_dto::create_jobs_table;
+
+    #[tokio::test]
+    async fn test_load_limits_jobs_per_user_per_service() {
+        // Setup in-memory SQLite database
+        let pool = SqlitePool::connect(":memory:")
+            .await
+            .unwrap_or_else(|e| panic!("Database connection failed: {e}"));
+        let mut config = Config::new().unwrap();
+        config.services.insert(
+            "A".to_string(),
+            Service {
+                name: "A".to_string(),
+                upload_url: "http://example.com/upload_a".to_string(),
+                download_url: "http://example.com/download_a".to_string(),
+                runs_per_user: 5,
+            },
+        );
+        config.services.insert(
+            "B".to_string(),
+            Service {
+                name: "B".to_string(),
+                upload_url: "http://example.com/upload_b".to_string(),
+                download_url: "http://example.com/download_b".to_string(),
+                runs_per_user: 5,
+            },
+        );
+
+        create_jobs_table(&pool).await.unwrap();
+
+        // Insert 5 submitted jobs for user 1 - service A
+        for _ in 0..5 {
+            sqlx::query("INSERT INTO jobs (user_id, service, status, loc, dest_id) VALUES (1, 'A', 'submitted', 'loc', NULL)")
+                .execute(&pool).await.unwrap();
+        }
+        // Insert 2 queued jobs for user 1 - service A
+        for _ in 0..2 {
+            sqlx::query("INSERT INTO jobs (user_id, service, status, loc, dest_id) VALUES (1, 'A', 'queued', 'loc', NULL)")
+                .execute(&pool).await.unwrap();
+        }
+
+        // Insert 3 submitted jobs for user 1 - service B
+        for _ in 0..3 {
+            sqlx::query("INSERT INTO jobs (user_id, service, status, loc, dest_id) VALUES (1, 'B', 'submitted', 'loc', NULL)")
+                .execute(&pool).await.unwrap();
+        }
+        // Insert 3 queued jobs for user 1 - service B
+        for _ in 0..3 {
+            sqlx::query("INSERT INTO jobs (user_id, service, status, loc, dest_id) VALUES (1, 'B', 'queued', 'loc', NULL)")
+                .execute(&pool).await.unwrap();
+        }
+
+        // Here user 1 has:
+        //  - 5 submitted / 2 queued jobs for service A
+        //  - 3 submitted / 3 queued jobs for service B
+
+        // Load the queue
+        let mut queue = Queue::new(&config);
+        queue.load(&pool).await.unwrap();
+
+        // User already has 5 submitted for service A,
+        // > no more queued jobs for service A should be loaded
+        let jobs_for_a = queue.jobs.iter().filter(|j| j.service == "A").count();
+        let expected_a = 0;
+        assert_eq!(jobs_for_a, expected_a,);
+        // User has 3 submitted and 3 queued for service B,
+        // > 2 more queued jobs for service B should be loaded, since max is 5
+        let jobs_for_b = queue.jobs.iter().filter(|j| j.service == "B").count();
+        let expected_b = 2;
+        assert_eq!(jobs_for_b, expected_b,);
+
+        // Add more jobs for another user
+        for _ in 0..2 {
+            sqlx::query("INSERT INTO jobs (user_id, service, status, loc, dest_id) VALUES (2, 'A', 'queued', 'loc', NULL)")
+                .execute(&pool).await.unwrap();
+        }
+
+        // Reload the queue
+        queue.load(&pool).await.unwrap();
+
+        // Now there should be 2 jobs for user 2 - service A
+        let jobs_for_a = queue.jobs.iter().filter(|j| j.service == "A").count();
+        let expected_a = 2;
+        assert_eq!(jobs_for_a, expected_a,);
     }
 }

--- a/src/services/orchestrator.rs
+++ b/src/services/orchestrator.rs
@@ -128,6 +128,7 @@ mod test {
                 name: service_name,
                 upload_url: "".to_string(),
                 download_url: "".to_string(),
+                runs_per_user: 5,
             },
         );
         let config = Config {
@@ -160,6 +161,7 @@ mod test {
                 name: service_name,
                 upload_url: "".to_string(),
                 download_url: "".to_string(),
+                runs_per_user: 5,
             },
         );
         let config = Config {
@@ -189,6 +191,7 @@ mod test {
                 name: service_name,
                 upload_url: "".to_string(),
                 download_url: "".to_string(),
+                runs_per_user: 5,
             },
         );
         let config = Config {
@@ -218,6 +221,7 @@ mod test {
                 name: service_name,
                 upload_url: "".to_string(),
                 download_url: "".to_string(),
+                runs_per_user: 5,
             },
         );
         let config = Config {
@@ -244,6 +248,7 @@ mod test {
                 name: "".to_string(),
                 upload_url: "".to_string(),
                 download_url: "".to_string(),
+                runs_per_user: 5,
             },
         );
         let config = Config {

--- a/src/services/tasks.rs
+++ b/src/services/tasks.rs
@@ -69,7 +69,7 @@ pub async fn cleaner(pool: SqlitePool, config: Config) {
 }
 
 pub async fn sender(pool: SqlitePool, config: Config) {
-    let mut queue = Queue::new();
+    let mut queue = Queue::new(&config);
     if queue.load(Status::Queued, &pool).await.is_ok() {
         // info!("{:?}", queue.jobs.len());
         let futures = queue
@@ -106,7 +106,7 @@ pub async fn sender(pool: SqlitePool, config: Config) {
 }
 
 pub async fn getter(pool: SqlitePool, config: Config) {
-    let mut queue = Queue::new();
+    let mut queue = Queue::new(&config);
     if queue
         .list_per_status(Status::Submitted, &pool)
         .await


### PR DESCRIPTION
This PR introduces a new configuration `RUNS_PER_USER` that aims to limit how many jobs a user can submit to a specific service. Once the quota is reached the jobs stay queued until new slots are freed based on the job execution.

# ===autogenerated===
This pull request introduces configurable per-user limits for job submissions per service, refactors the queue logic to enforce these limits, and updates documentation and deployment configuration to reflect the new behavior. The changes ensure that users cannot exceed a specified number of concurrent jobs for each service, with the limit now being configurable via environment variables.

**Configurable per-user service limits and queue enforcement:**

* Added `runs_per_user` field to the `Service` struct in `Config`, and updated environment variable parsing to support `SERVICE_<NAME>_RUNS_PER_USER` for setting per-user job limits per service. The default is 5 if not specified. [[1]](diffhunk://#diff-2f2af8ebb621128659768ef7407f04feab096fa5e9dee1a885dd8265ccd8ee7fR21) [[2]](diffhunk://#diff-2f2af8ebb621128659768ef7407f04feab096fa5e9dee1a885dd8265ccd8ee7fL29-R38) [[3]](diffhunk://#diff-2f2af8ebb621128659768ef7407f04feab096fa5e9dee1a885dd8265ccd8ee7fR47-R56)
* Refactored the queue logic in `Queue` (`src/models/queue_dto.rs`) to enforce per-user, per-service job submission limits based on the configuration. The queue now only loads jobs if the user has not reached their limit for that service.
* Updated the queue's constructor and usage to require a reference to the configuration, ensuring limits are enforced wherever the queue is used. [[1]](diffhunk://#diff-41e24ec491561145862db098ccb26d2bd24cae94363bcdde3dc640acd7214421R2-R15) [[2]](diffhunk://#diff-2642e4ecf01be9723d630413f7426b166ceddddfc43c1112b4a8ecb8e622d5cfL72-R75)

**Testing and validation:**

* Added comprehensive tests to verify that the queue correctly enforces per-user, per-service job limits, including edge cases for different users and services with varying limits.

**Documentation and deployment updates:**

* Updated `deployment/docker_compose.yml` to expose the new environment variable (`SERVICE_GENERIC_RUNS_PER_USER`) and changed the orchestrator port to 5000.
* Expanded the `README.md` with a detailed example deployment section, including usage instructions and expected API responses.

**Minor improvements:**

* Various small documentation and cosmetic fixes, such as capitalization and line wrapping. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R149)

These changes collectively provide a more robust and configurable job orchestration system, making it easier to manage user quotas and improve operational transparency.