### PR TITLE
add routes to retrieve partial data

### DIFF
--- a/src/controllers/client.rs
+++ b/src/controllers/client.rs
@@ -532,6 +532,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_retrieve_partial_zip_error() {
+        let tempdir = TempDir::new().unwrap();
+        let pool = setup_test_db().await;
+        let config = make_config(tempdir.path().to_str().unwrap());
+
+        let mut payload = Payload::new();
+        payload.add_to_db(&pool).await.unwrap();
+        let payload_id = payload.id;
+
+        // Set an invalid/non-existent directory
+        let invalid_dir = tempdir.path().join("nonexistent");
+        payload.set_loc(invalid_dir);
+        payload.update_loc(&pool).await.unwrap();
+
+        let app = create_client_routes(pool, config);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("/retrieve_partial/{payload_id}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let bytes = body_bytes(response).await;
+        let payload_resp: Payload = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload_resp.id, 0);
+    }
+
+    #[tokio::test]
     async fn test_load() {
         let tempdir = TempDir::new().unwrap();
         let pool = setup_test_db().await;

--- a/src/controllers/client.rs
+++ b/src/controllers/client.rs
@@ -112,6 +112,43 @@ pub async fn retrieve(State(state): State<AppState>, Path(id): Path<u32>) -> Res
 
 #[utoipa::path(
     get,
+    path = "/retrieve_partial/{id}",
+    params(
+        ("id" = i32, Path, description = "Payload identifier")
+    ),
+    responses(
+       (status = 200, description = "Returns zip file of current payload state, regardless of completion", content_type = "application/zip", body = Vec<u8>),
+       (status = 404, description = "Payload not found", body = Payload),
+       (status = 500, description = "Internal server error", body = Payload),
+   ),
+    tag = "files"
+)]
+pub async fn retrieve_partial(State(state): State<AppState>, Path(id): Path<u32>) -> Response {
+    let payload = match Payload::retrieve_id(id, &state.pool).await {
+        Ok(p) => p,
+        // TODO: Empty payload responses are indicators of an unhealthy client — handle in a future PR.
+        Err(e) => {
+            let status = match e {
+                sqlx::Error::RowNotFound => StatusCode::NOT_FOUND,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            return (status, Json(Payload::new())).into_response();
+        }
+    };
+
+    // Always return the zip, regardless of status
+    match payload.zip_partial() {
+        Ok(v) => ([(header::CONTENT_TYPE, "application/zip")], v).into_response(),
+        // TODO: Empty payload response is an indicator of an unhealthy client — handle in a future PR.
+        Err(e) => {
+            tracing::error!("Error compressing directory {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(Payload::new())).into_response()
+        }
+    }
+}
+
+#[utoipa::path(
+    get,
     path = "/load",
     responses(
         (status = 200, description = "Get the load of the client", body = f32),
@@ -169,6 +206,7 @@ mod tests {
     use sqlx::SqlitePool;
     use std::collections::HashMap;
     use std::fs;
+    use std::io::Read;
     use tempfile::TempDir;
     use tower::ServiceExt;
 
@@ -379,6 +417,118 @@ mod tests {
 
         let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_not_found() {
+        let tempdir = TempDir::new().unwrap();
+        let pool = setup_test_db().await;
+        let config = make_config(tempdir.path().to_str().unwrap());
+        let app = create_client_routes(pool, config);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("/retrieve_partial/9999")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_non_completed() {
+        let tempdir = TempDir::new().unwrap();
+        let pool = setup_test_db().await;
+        let config = make_config(tempdir.path().to_str().unwrap());
+
+        let mut payload = Payload::new();
+        payload.add_to_db(&pool).await.unwrap();
+        payload
+            .update_status(Status::Prepared, &pool)
+            .await
+            .unwrap();
+
+        // Create payload directory with files
+        let payload_dir = tempdir.path().join(payload.id.to_string());
+        fs::create_dir_all(&payload_dir).unwrap();
+        fs::write(&payload_dir.join("test.txt"), b"partial data").unwrap();
+        payload.set_loc(payload_dir);
+        payload.update_loc(&pool).await.unwrap();
+
+        let payload_id = payload.id;
+
+        let app = create_client_routes(pool, config);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("/retrieve_partial/{payload_id}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(content_type, "application/zip");
+
+        // Verify the zip contains our test file
+        let bytes = body_bytes(response).await;
+        assert!(!bytes.is_empty());
+
+        // Unzip and verify contents
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor).unwrap();
+        assert!(archive.len() > 0);
+
+        let mut file = archive.by_name("test.txt").unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "partial data");
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_completed() {
+        let tempdir = TempDir::new().unwrap();
+        let pool = setup_test_db().await;
+        let config = make_config(tempdir.path().to_str().unwrap());
+
+        let mut payload = Payload::new();
+        payload.add_to_db(&pool).await.unwrap();
+        let payload_id = payload.id;
+
+        let payload_dir = tempdir.path().join(payload_id.to_string());
+        fs::create_dir_all(&payload_dir).unwrap();
+        fs::write(payload_dir.join("output.txt"), b"result data").unwrap();
+
+        payload.set_loc(payload_dir);
+        payload.update_loc(&pool).await.unwrap();
+        payload
+            .update_status(Status::Completed, &pool)
+            .await
+            .unwrap();
+
+        let app = create_client_routes(pool, config);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("/retrieve_partial/{payload_id}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(content_type, "application/zip");
     }
 
     #[tokio::test]

--- a/src/controllers/server.rs
+++ b/src/controllers/server.rs
@@ -844,6 +844,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_download_partial_invalid_service() {
+        let tempdir = TempDir::new().unwrap();
+        let pool = setup_test_db().await;
+        let mut config = make_config(tempdir.path().to_str().unwrap());
+
+        // Remove the test service to trigger InvalidService error
+        config.services.clear();
+
+        // Create and add a job to the database
+        let mut job = Job::new(tempdir.path().to_str().unwrap());
+        job.set_user_id(1);
+        job.set_service("nonexistent".to_string());
+        job.add_to_db(&pool).await.unwrap();
+        job.update_dest_id(42, &pool).await.unwrap();
+        job.update_status(Status::Running, &pool).await.unwrap();
+        let job_id = job.id;
+
+        let app = create_routes(pool, config);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("/download_partial/{job_id}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let bytes = body_bytes(response).await;
+        let body: StatusBody = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            body.message.to_lowercase().contains("invalid service"),
+            "Expected 'invalid service' message, got: {}",
+            body.message
+        );
+    }
+
+    #[tokio::test]
     async fn test_terminate_not_found() {
         let tempdir = TempDir::new().unwrap();
         let pool = setup_test_db().await;

--- a/src/controllers/server.rs
+++ b/src/controllers/server.rs
@@ -325,7 +325,6 @@ mod tests {
     use sqlx::SqlitePool;
     use std::collections::HashMap;
     use std::fs;
-    use std::io::Read;
     use tempfile::TempDir;
     use tower::ServiceExt;
 

--- a/src/controllers/server.rs
+++ b/src/controllers/server.rs
@@ -68,6 +68,54 @@ pub async fn download(State(state): State<AppState>, Path(id): Path<u32>) -> Res
 }
 
 #[utoipa::path(
+    get,
+    path = "/download_partial/{id}",
+    params(
+        ("id" = u32, Path, description = "Job identifier")
+    ),
+    responses(
+        (status = 200, description = "Returns zip file of current job state, regardless of completion", content_type = "application/zip", body = Vec<u8>),
+        (status = 404, description = "Not found", body = StatusBody),
+        (status = 500, description = "Internal server error", body = StatusBody),
+    ),
+    tag = "files"
+)]
+pub async fn download_partial(State(state): State<AppState>, Path(id): Path<u32>) -> Response {
+    let mut job = Job::new(&state.config.data_path);
+    let mut body = StatusBody::new();
+
+    let result = job.retrieve_id(id, &state.pool).await;
+
+    if let Err(e) = result {
+        // Error when retrieving this id, check what kind of error it was
+        let status = match e {
+            // It is not found on the database
+            sqlx::Error::RowNotFound => {
+                body.message = format!("Job {id} not found in the database");
+                StatusCode::NOT_FOUND
+            }
+            // Something else
+            _ => {
+                body.message = "Internal server error".to_string();
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+        // Return the error
+        return (status, Json(body)).into_response();
+    }
+
+    // Always return the zip, regardless of status
+    match job.download_partial() {
+        Ok(data) => ([(header::CONTENT_TYPE, "application/zip")], data).into_response(),
+        Err(e) => {
+            tracing::error!("Error reading job directory: {:?}", e);
+            body.message = "Error reading job directory".to_string();
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+        }
+    }
+}
+
+#[utoipa::path(
     post,
     path = "/upload",
     request_body(
@@ -260,6 +308,7 @@ mod tests {
     use sqlx::SqlitePool;
     use std::collections::HashMap;
     use std::fs;
+    use std::io::Read;
     use tempfile::TempDir;
     use tower::ServiceExt;
 
@@ -652,6 +701,123 @@ mod tests {
             "Expected error about output file, got: {}",
             body.message
         );
+    }
+
+    #[tokio::test]
+    async fn test_download_partial_not_found() {
+        let tempdir = TempDir::new().unwrap();
+        let pool = setup_test_db().await;
+        let config = make_config(tempdir.path().to_str().unwrap());
+        let app = create_routes(pool, config);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("/download_partial/9999")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let bytes = body_bytes(response).await;
+        let body: StatusBody = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            body.message.to_lowercase().contains("not found") && body.message.contains("9999"),
+            "Expected 'not found' message mentioning job id, got: {}",
+            body.message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_partial_queued_job() {
+        let tempdir = TempDir::new().unwrap();
+        let pool = setup_test_db().await;
+        let config = make_config(tempdir.path().to_str().unwrap());
+
+        let mut job = Job::new(tempdir.path().to_str().unwrap());
+        job.set_user_id(1);
+        job.set_service("test".to_string());
+        job.add_to_db(&pool).await.unwrap();
+        job.update_status(Status::Queued, &pool).await.unwrap();
+
+        // Create the job directory with some files
+        fs::create_dir_all(&job.loc).unwrap();
+        fs::write(job.loc.join("test.txt"), b"test data").unwrap();
+
+        let job_id = job.id;
+
+        let app = create_routes(pool, config);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("/download_partial/{job_id}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(content_type, "application/zip");
+
+        // Verify the zip contains our test file
+        let bytes = body_bytes(response).await;
+        assert!(!bytes.is_empty());
+
+        // Unzip and verify contents
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor).unwrap();
+        assert!(archive.len() > 0);
+
+        let mut file = archive.by_name("test.txt").unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "test data");
+    }
+
+    #[tokio::test]
+    async fn test_download_partial_running_job() {
+        let tempdir = TempDir::new().unwrap();
+        let pool = setup_test_db().await;
+        let config = make_config(tempdir.path().to_str().unwrap());
+
+        let mut job = Job::new(tempdir.path().to_str().unwrap());
+        job.set_user_id(1);
+        job.set_service("test".to_string());
+        job.add_to_db(&pool).await.unwrap();
+        job.update_status(Status::Running, &pool).await.unwrap();
+
+        // Create the job directory with some files
+        fs::create_dir_all(&job.loc).unwrap();
+        fs::write(job.loc.join("output.txt"), b"partial output").unwrap();
+
+        let job_id = job.id;
+
+        let app = create_routes(pool, config);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("/download_partial/{job_id}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(content_type, "application/zip");
+
+        // Verify the zip contains our test file
+        let bytes = body_bytes(response).await;
+        assert!(!bytes.is_empty());
     }
 
     #[tokio::test]

--- a/src/controllers/server.rs
+++ b/src/controllers/server.rs
@@ -2,8 +2,10 @@ use crate::models::job_dao::Job;
 use crate::models::status_body::StatusBody;
 use crate::models::status_dto::Status;
 use crate::routes::router::AppState;
+use crate::services::endpoint::{retrieve_partial, DownloadPartialError};
 use crate::services::server;
 use crate::utils::io::{sanitize_filename, save_file};
+use crate::services::client::Client;
 use axum::response::{IntoResponse, Response};
 use axum::{
     extract::{Json, Multipart, Path, State},
@@ -104,13 +106,28 @@ pub async fn download_partial(State(state): State<AppState>, Path(id): Path<u32>
         return (status, Json(body)).into_response();
     }
 
-    // Always return the zip, regardless of status
-    match job.download_partial() {
+    body.id = job.id;
+
+    // Call the client's retrieve_partial endpoint to get the current state
+    match retrieve_partial(&job, &state.config, Client).await {
         Ok(data) => ([(header::CONTENT_TYPE, "application/zip")], data).into_response(),
         Err(e) => {
-            tracing::error!("Error reading job directory: {:?}", e);
-            body.message = "Error reading job directory".to_string();
-            (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+            tracing::error!("Error retrieving partial data from client: {:?}", e);
+            let status = match e {
+                DownloadPartialError::NotFound => {
+                    body.message = "Job payload not found on client".to_string();
+                    StatusCode::NOT_FOUND
+                }
+                DownloadPartialError::InvalidService => {
+                    body.message = "Invalid service configuration".to_string();
+                    StatusCode::BAD_REQUEST
+                }
+                _ => {
+                    body.message = "Error retrieving partial data from client".to_string();
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            };
+            (status, Json(body)).into_response()
         }
     }
 }
@@ -729,24 +746,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_download_partial_queued_job() {
+    async fn test_download_partial_success() {
         let tempdir = TempDir::new().unwrap();
         let pool = setup_test_db().await;
         let config = make_config(tempdir.path().to_str().unwrap());
 
+        // Create and add a job to the database
         let mut job = Job::new(tempdir.path().to_str().unwrap());
         job.set_user_id(1);
         job.set_service("test".to_string());
         job.add_to_db(&pool).await.unwrap();
-        job.update_status(Status::Queued, &pool).await.unwrap();
-
-        // Create the job directory with some files
-        fs::create_dir_all(&job.loc).unwrap();
-        fs::write(job.loc.join("test.txt"), b"test data").unwrap();
-
+        job.update_dest_id(42, &pool).await.unwrap();
+        job.update_status(Status::Running, &pool).await.unwrap();
         let job_id = job.id;
 
-        let app = create_routes(pool, config);
+        // Mock the retrieve_partial endpoint
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/retrieve_partial/42")
+            .with_status(200)
+            .with_header("content-type", "application/zip")
+            .with_body(b"fake partial zip content")
+            .create_async()
+            .await;
+
+        // Update config to use mock server URL
+        let mut config_with_mock = config;
+        if let Some(service) = config_with_mock.services.get_mut("test") {
+            service.download_url = format!("{}/retrieve", server.url());
+        }
+
+        let app = create_routes(pool, config_with_mock);
 
         let request = Request::builder()
             .method("GET")
@@ -764,40 +794,42 @@ mod tests {
             .unwrap_or("");
         assert_eq!(content_type, "application/zip");
 
-        // Verify the zip contains our test file
         let bytes = body_bytes(response).await;
-        assert!(!bytes.is_empty());
+        assert_eq!(&bytes[..], b"fake partial zip content");
 
-        // Unzip and verify contents
-        let cursor = std::io::Cursor::new(bytes);
-        let mut archive = zip::ZipArchive::new(cursor).unwrap();
-        assert!(archive.len() > 0);
-
-        let mut file = archive.by_name("test.txt").unwrap();
-        let mut contents = String::new();
-        file.read_to_string(&mut contents).unwrap();
-        assert_eq!(contents, "test data");
+        mock.assert_async().await;
     }
 
     #[tokio::test]
-    async fn test_download_partial_running_job() {
+    async fn test_download_partial_client_not_found() {
         let tempdir = TempDir::new().unwrap();
         let pool = setup_test_db().await;
         let config = make_config(tempdir.path().to_str().unwrap());
 
+        // Create and add a job to the database
         let mut job = Job::new(tempdir.path().to_str().unwrap());
         job.set_user_id(1);
         job.set_service("test".to_string());
         job.add_to_db(&pool).await.unwrap();
+        job.update_dest_id(42, &pool).await.unwrap();
         job.update_status(Status::Running, &pool).await.unwrap();
-
-        // Create the job directory with some files
-        fs::create_dir_all(&job.loc).unwrap();
-        fs::write(job.loc.join("output.txt"), b"partial output").unwrap();
-
         let job_id = job.id;
 
-        let app = create_routes(pool, config);
+        // Mock the retrieve_partial endpoint to return 404
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/retrieve_partial/42")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        // Update config to use mock server URL
+        let mut config_with_mock = config;
+        if let Some(service) = config_with_mock.services.get_mut("test") {
+            service.download_url = format!("{}/retrieve", server.url());
+        }
+
+        let app = create_routes(pool, config_with_mock);
 
         let request = Request::builder()
             .method("GET")
@@ -806,18 +838,9 @@ mod tests {
             .unwrap();
 
         let response = app.oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-        let content_type = response
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        assert_eq!(content_type, "application/zip");
-
-        // Verify the zip contains our test file
-        let bytes = body_bytes(response).await;
-        assert!(!bytes.is_empty());
+        mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/src/controllers/server.rs
+++ b/src/controllers/server.rs
@@ -2,10 +2,10 @@ use crate::models::job_dao::Job;
 use crate::models::status_body::StatusBody;
 use crate::models::status_dto::Status;
 use crate::routes::router::AppState;
-use crate::services::endpoint::{retrieve_partial, DownloadPartialError};
+use crate::services::client::Client;
+use crate::services::endpoint;
 use crate::services::server;
 use crate::utils::io::{sanitize_filename, save_file};
-use crate::services::client::Client;
 use axum::response::{IntoResponse, Response};
 use axum::{
     extract::{Json, Multipart, Path, State},
@@ -109,16 +109,16 @@ pub async fn download_partial(State(state): State<AppState>, Path(id): Path<u32>
     body.id = job.id;
 
     // Call the client's retrieve_partial endpoint to get the current state
-    match retrieve_partial(&job, &state.config, Client).await {
+    match endpoint::retrieve_partial(&job, &state.config, Client).await {
         Ok(data) => ([(header::CONTENT_TYPE, "application/zip")], data).into_response(),
         Err(e) => {
             tracing::error!("Error retrieving partial data from client: {:?}", e);
             let status = match e {
-                DownloadPartialError::NotFound => {
+                endpoint::DownloadPartialError::NotFound => {
                     body.message = "Job payload not found on client".to_string();
                     StatusCode::NOT_FOUND
                 }
-                DownloadPartialError::InvalidService => {
+                endpoint::DownloadPartialError::InvalidService => {
                     body.message = "Invalid service configuration".to_string();
                     StatusCode::BAD_REQUEST
                 }

--- a/src/models/job_dao.rs
+++ b/src/models/job_dao.rs
@@ -1,4 +1,5 @@
 use crate::models::status_dto::Status;
+use crate::utils;
 use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
@@ -36,6 +37,14 @@ impl Job {
         Ok(buffer)
     }
 
+    /// Zip the job directory to bytes, regardless of its current state.
+    /// This is used for partial downloads to debug stuck or incomplete runs.
+    pub fn download_partial(self) -> Result<Vec<u8>, std::io::Error> {
+        // Zip the directory to bytes directly
+        utils::io::zip_directory_to_bytes(&self.loc)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    }
+
     pub fn remove_from_disk(&self) -> Result<(), std::io::Error> {
         fs::remove_dir_all(&self.loc)
     }
@@ -58,6 +67,7 @@ mod test {
 
     use super::*;
     use std::fs;
+    use std::io::Read;
     use std::path::Path;
     use tempfile::TempDir;
 
@@ -102,5 +112,46 @@ mod test {
         let mut job = Job::new("");
         job.set_user_id(99);
         assert_eq!(job.user_id, 99)
+    }
+
+    #[test]
+    fn test_download_partial() {
+        let tempdir = TempDir::new().unwrap();
+        let job = Job::new(tempdir.path().to_str().unwrap());
+
+        // Create job directory with some files
+        fs::create_dir_all(&job.loc).unwrap();
+        fs::write(job.loc.join("file1.txt"), b"data 1").unwrap();
+        fs::write(job.loc.join("file2.txt"), b"data 2").unwrap();
+
+        let result = job.download_partial().unwrap();
+        assert!(!result.is_empty());
+
+        // Verify the zip contains our files
+        let cursor = std::io::Cursor::new(result);
+        let mut archive = zip::ZipArchive::new(cursor).unwrap();
+        assert!(archive.len() >= 2);
+
+        let mut file1 = archive.by_name("file1.txt").unwrap();
+        let mut contents = String::new();
+        file1.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "data 1");
+    }
+
+    #[test]
+    fn test_download_partial_empty_directory() {
+        let tempdir = TempDir::new().unwrap();
+        let job = Job::new(tempdir.path().to_str().unwrap());
+
+        // Create empty job directory
+        fs::create_dir_all(&job.loc).unwrap();
+
+        let result = job.download_partial().unwrap();
+        assert!(!result.is_empty());
+
+        // Verify the zip is empty
+        let cursor = std::io::Cursor::new(result);
+        let archive = zip::ZipArchive::new(cursor).unwrap();
+        assert_eq!(archive.len(), 0);
     }
 }

--- a/src/models/job_dao.rs
+++ b/src/models/job_dao.rs
@@ -1,5 +1,4 @@
 use crate::models::status_dto::Status;
-use crate::utils;
 use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
@@ -37,14 +36,6 @@ impl Job {
         Ok(buffer)
     }
 
-    /// Zip the job directory to bytes, regardless of its current state.
-    /// This is used for partial downloads to debug stuck or incomplete runs.
-    pub fn download_partial(self) -> Result<Vec<u8>, std::io::Error> {
-        // Zip the directory to bytes directly
-        utils::io::zip_directory_to_bytes(&self.loc)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-    }
-
     pub fn remove_from_disk(&self) -> Result<(), std::io::Error> {
         fs::remove_dir_all(&self.loc)
     }
@@ -67,7 +58,6 @@ mod test {
 
     use super::*;
     use std::fs;
-    use std::io::Read;
     use std::path::Path;
     use tempfile::TempDir;
 
@@ -112,46 +102,5 @@ mod test {
         let mut job = Job::new("");
         job.set_user_id(99);
         assert_eq!(job.user_id, 99)
-    }
-
-    #[test]
-    fn test_download_partial() {
-        let tempdir = TempDir::new().unwrap();
-        let job = Job::new(tempdir.path().to_str().unwrap());
-
-        // Create job directory with some files
-        fs::create_dir_all(&job.loc).unwrap();
-        fs::write(job.loc.join("file1.txt"), b"data 1").unwrap();
-        fs::write(job.loc.join("file2.txt"), b"data 2").unwrap();
-
-        let result = job.download_partial().unwrap();
-        assert!(!result.is_empty());
-
-        // Verify the zip contains our files
-        let cursor = std::io::Cursor::new(result);
-        let mut archive = zip::ZipArchive::new(cursor).unwrap();
-        assert!(archive.len() >= 2);
-
-        let mut file1 = archive.by_name("file1.txt").unwrap();
-        let mut contents = String::new();
-        file1.read_to_string(&mut contents).unwrap();
-        assert_eq!(contents, "data 1");
-    }
-
-    #[test]
-    fn test_download_partial_empty_directory() {
-        let tempdir = TempDir::new().unwrap();
-        let job = Job::new(tempdir.path().to_str().unwrap());
-
-        // Create empty job directory
-        fs::create_dir_all(&job.loc).unwrap();
-
-        let result = job.download_partial().unwrap();
-        assert!(!result.is_empty());
-
-        // Verify the zip is empty
-        let cursor = std::io::Cursor::new(result);
-        let archive = zip::ZipArchive::new(cursor).unwrap();
-        assert_eq!(archive.len(), 0);
     }
 }

--- a/src/models/payload_dao.rs
+++ b/src/models/payload_dao.rs
@@ -84,8 +84,7 @@ impl Payload {
     /// Unlike zip_directory, this does not create or read from output.zip.
     pub fn zip_partial(self) -> Result<Vec<u8>, std::io::Error> {
         // Zip the directory to bytes directly without using output.zip
-        utils::io::zip_directory_to_bytes(&self.loc)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        utils::io::zip_directory_to_bytes(&self.loc).map_err(std::io::Error::other)
     }
 
     pub fn execute(&mut self) -> Result<(), ClientError> {
@@ -306,10 +305,10 @@ mod test {
         p.pid = child.id();
         // Give the process a moment to start
         std::thread::sleep(std::time::Duration::from_millis(200));
-        
+
         // kill() should return Ok if the kill command succeeds
         assert!(p.kill().is_ok());
-        
+
         // Wait for the process to avoid zombie
         let _ = child.wait();
     }

--- a/src/models/payload_dao.rs
+++ b/src/models/payload_dao.rs
@@ -79,6 +79,15 @@ impl Payload {
         std::fs::read(&result)
     }
 
+    /// Zip the payload directory to bytes, regardless of its current state.
+    /// This is used for partial downloads to debug stuck or incomplete runs.
+    /// Unlike zip_directory, this does not create or read from output.zip.
+    pub fn zip_partial(self) -> Result<Vec<u8>, std::io::Error> {
+        // Zip the directory to bytes directly without using output.zip
+        utils::io::zip_directory_to_bytes(&self.loc)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    }
+
     pub fn execute(&mut self) -> Result<(), ClientError> {
         let run_script = self.loc.join(RUN_FILE);
         utils::io::validate_script(&run_script)?;
@@ -146,6 +155,7 @@ impl Payload {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::io::Read;
 
     #[tokio::test]
     async fn test_add_input() {
@@ -302,5 +312,67 @@ mod test {
         
         // Wait for the process to avoid zombie
         let _ = child.wait();
+    }
+
+    #[tokio::test]
+    async fn test_zip_partial() {
+        let mut p = Payload::new();
+        let temp_dir = tempfile::tempdir().unwrap();
+        p.loc = temp_dir.path().to_path_buf();
+
+        // Create some files in the payload directory
+        fs::create_dir_all(&p.loc).unwrap();
+        fs::write(p.loc.join("test.txt"), b"test data").unwrap();
+        fs::write(p.loc.join("output.txt"), b"output data").unwrap();
+
+        // Call zip_partial
+        let result = p.zip_partial();
+        assert!(result.is_ok());
+
+        let bytes = result.unwrap();
+        assert!(!bytes.is_empty());
+
+        // Verify the zip contains both files
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor).unwrap();
+        assert!(archive.len() >= 2);
+
+        // Verify we can read the first file
+        {
+            let mut test_file = archive.by_name("test.txt").unwrap();
+            let mut contents = String::new();
+            test_file.read_to_string(&mut contents).unwrap();
+            assert_eq!(contents, "test data");
+        }
+
+        // Verify we can read the second file
+        {
+            let mut output_file = archive.by_name("output.txt").unwrap();
+            let mut output_contents = String::new();
+            output_file.read_to_string(&mut output_contents).unwrap();
+            assert_eq!(output_contents, "output data");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_zip_partial_empty_directory() {
+        let mut p = Payload::new();
+        let temp_dir = tempfile::tempdir().unwrap();
+        p.loc = temp_dir.path().to_path_buf();
+
+        // Create empty directory
+        fs::create_dir_all(&p.loc).unwrap();
+
+        // Call zip_partial
+        let result = p.zip_partial();
+        assert!(result.is_ok());
+
+        let bytes = result.unwrap();
+        assert!(!bytes.is_empty());
+
+        // Verify the zip is empty
+        let cursor = std::io::Cursor::new(bytes);
+        let archive = zip::ZipArchive::new(cursor).unwrap();
+        assert_eq!(archive.len(), 0);
     }
 }

--- a/src/routes/router.rs
+++ b/src/routes/router.rs
@@ -1,11 +1,12 @@
 use crate::config::loader::Config;
-use crate::controllers::client::{kill, load, retrieve, submit};
+use crate::controllers::client::{kill, load, retrieve, retrieve_partial, submit};
 use crate::controllers::health::__path_health;
 use crate::controllers::health::health;
 use crate::controllers::ping::ping;
 use crate::controllers::server::__path_download;
+use crate::controllers::server::__path_download_partial;
 use crate::controllers::server::__path_upload;
-use crate::controllers::server::{download, terminate, upload};
+use crate::controllers::server::{download, download_partial, terminate, upload};
 use crate::models::health_dto::Health;
 use crate::models::job_dao::Job;
 use axum::extract::DefaultBodyLimit;
@@ -32,6 +33,7 @@ pub struct AppState {
     paths(
         upload,
         download,
+        download_partial,
         health
     ),
     components(
@@ -51,6 +53,7 @@ pub fn create_routes(pool: SqlitePool, config: Config) -> Router {
         .route("/health", get(health))
         .route("/upload", post(upload))
         .route("/download/{id}", get(download))
+        .route("/download_partial/{id}", get(download_partial))
         .route("/terminate/{id}", post(terminate))
         .merge(SwaggerUi::new("/swagger").url("/api-docs/openapi.json", ApiDoc::openapi()))
         .with_state(state)
@@ -79,6 +82,7 @@ pub fn create_client_routes(pool: SqlitePool, config: Config) -> Router {
         .route("/load", get(load))
         .route("/submit", post(submit))
         .route("/retrieve/{id}", get(retrieve))
+        .route("/retrieve_partial/{id}", get(retrieve_partial))
         .route("/kill/{id}", post(kill))
         .with_state(state)
         .layer(

--- a/src/services/client.rs
+++ b/src/services/client.rs
@@ -192,7 +192,7 @@ impl Endpoint for Client {
         let client = reqwest::Client::new();
         // Append the job id to the url
         let response = client
-            .get(format!("{url}/{0}", j.dest_id))
+            .get(format!("{}/{}", url, j.dest_id))
             .send()
             .await
             .map_err(DownloadPartialError::RequestFailed)?;

--- a/src/services/client.rs
+++ b/src/services/client.rs
@@ -2,7 +2,7 @@ use crate::models::status_dto::Status;
 
 use crate::models::job_dao::Job;
 use crate::models::payload_dao::Payload;
-use crate::services::endpoint::{DownloadError, UploadError};
+use crate::services::endpoint::{DownloadError, DownloadPartialError, UploadError};
 use crate::services::endpoint::{Endpoint, TerminateError};
 use futures_util::StreamExt;
 use reqwest::multipart::{Form, Part};
@@ -183,6 +183,46 @@ impl Endpoint for Client {
             // Client returned an error
             tracing::error!("Client returned error status: {status}");
             Err(DownloadError::RequestFailed(
+                response.error_for_status().unwrap_err(),
+            ))
+        }
+    }
+
+    async fn download_partial(&self, j: &Job, url: &str) -> Result<Vec<u8>, DownloadPartialError> {
+        let client = reqwest::Client::new();
+        // Append the job id to the url
+        let response = client
+            .get(format!("{url}/{0}", j.dest_id))
+            .send()
+            .await
+            .map_err(DownloadPartialError::RequestFailed)?;
+
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        if status == StatusCode::OK && content_type.contains("application/zip") {
+            // Return the zip bytes
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(DownloadPartialError::ResponseReadFailed)?;
+            Ok(bytes.to_vec())
+        } else if status == StatusCode::NOT_FOUND {
+            // Payload not found on client
+            Err(DownloadPartialError::NotFound)
+        } else if status.is_success() {
+            // Unexpected success status without zip content
+            Err(DownloadPartialError::ResponseReadFailed(
+                response.error_for_status().unwrap_err(),
+            ))
+        } else {
+            // Client returned an error
+            tracing::error!("Client returned error status: {status}");
+            Err(DownloadPartialError::RequestFailed(
                 response.error_for_status().unwrap_err(),
             ))
         }
@@ -507,6 +547,64 @@ mod test {
 
         mock.assert_async().await;
         assert_eq!(result.unwrap(), crate::models::status_dto::Status::Running);
+    }
+
+    #[tokio::test]
+    async fn test_client_download_partial_success() {
+        let mut server = Server::new_async().await;
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        // Create a job
+        let mut job = Job::new(temp_dir.path().to_str().unwrap());
+        job.set_user_id(1);
+        job.set_service("test".to_string());
+        job.dest_id = 123;
+
+        // Mock server response with zip content
+        let mock = server
+            .mock("GET", "/retrieve_partial/123")
+            .with_status(200)
+            .with_header("content-type", "application/zip")
+            .with_body(b"partial zip content")
+            .create_async()
+            .await;
+
+        let client = Client;
+        let url = format!("{}/retrieve_partial", server.url());
+        let result = client.download_partial(&job, &url).await;
+
+        mock.assert_async().await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), b"partial zip content");
+    }
+
+    #[tokio::test]
+    async fn test_client_download_partial_not_found() {
+        let mut server = Server::new_async().await;
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut job = Job::new(temp_dir.path().to_str().unwrap());
+        job.set_user_id(1);
+        job.set_service("test".to_string());
+        job.dest_id = 456;
+
+        // Mock server response with 404
+        let mock = server
+            .mock("GET", "/retrieve_partial/456")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let client = Client;
+        let url = format!("{}/retrieve_partial", server.url());
+        let result = client.download_partial(&job, &url).await;
+
+        mock.assert_async().await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DownloadPartialError::NotFound => {}
+            _ => panic!("Expected NotFound error"),
+        }
     }
 
     #[tokio::test]

--- a/src/services/client.rs
+++ b/src/services/client.rs
@@ -216,9 +216,12 @@ impl Endpoint for Client {
             Err(DownloadPartialError::NotFound)
         } else if status.is_success() {
             // Unexpected success status without zip content
-            Err(DownloadPartialError::ResponseReadFailed(
-                response.error_for_status().unwrap_err(),
-            ))
+            tracing::error!(
+                "Unexpected HTTP {} with content-type {} (expected application/zip)",
+                status.as_u16(),
+                content_type
+            );
+            Err(DownloadPartialError::UnexpectedStatus(status.as_u16()))
         } else {
             // Client returned an error
             tracing::error!("Client returned error status: {status}");
@@ -606,6 +609,40 @@ mod test {
         match result.unwrap_err() {
             DownloadPartialError::NotFound => {}
             _ => panic!("Expected NotFound error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_client_download_partial_unexpected_content_type() {
+        let mut server = Server::new_async().await;
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut job = Job::new(temp_dir.path().to_str().unwrap());
+        job.set_user_id(1);
+        job.set_service("test".to_string());
+        job.dest_id = 789;
+
+        // Mock server response with 200 but wrong content type (no zip)
+        // The code uses format!("{url}/{0}", j.dest_id) which appends dest_id to url
+        let mock = server
+            .mock("GET", "/retrieve_partial/789")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body(b"not a zip file")
+            .create_async()
+            .await;
+
+        let client = Client;
+        let url = format!("{}/retrieve_partial", server.url());
+        let result = client.download_partial(&job, &url).await;
+
+        mock.assert_async().await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DownloadPartialError::UnexpectedStatus(status) => {
+                assert_eq!(status, 200);
+            }
+            _ => panic!("Expected UnexpectedStatus error for non-zip content"),
         }
     }
 

--- a/src/services/client.rs
+++ b/src/services/client.rs
@@ -561,6 +561,7 @@ mod test {
         job.dest_id = 123;
 
         // Mock server response with zip content
+        // The code uses format!("{url}/{0}", j.dest_id) which appends dest_id to url
         let mock = server
             .mock("GET", "/retrieve_partial/123")
             .with_status(200)
@@ -589,6 +590,7 @@ mod test {
         job.dest_id = 456;
 
         // Mock server response with 404
+        // The code uses format!("{url}/{0}", j.dest_id) which appends dest_id to url
         let mock = server
             .mock("GET", "/retrieve_partial/456")
             .with_status(404)
@@ -881,6 +883,37 @@ mod test {
         match result.unwrap_err() {
             TerminateError::GenericError => {}
             _ => panic!("Expected GenericError"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_client_download_partial_client_error() {
+        let mut server = Server::new_async().await;
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let mut job = Job::new(temp_dir.path().to_str().unwrap());
+        job.set_user_id(1);
+        job.set_service("test".to_string());
+        job.dest_id = 999;
+
+        // Mock server response with 500 error
+        // The code uses format!("{url}/{0}", j.dest_id) which appends dest_id to url
+        let mock = server
+            .mock("GET", "/retrieve_partial/999")
+            .with_status(500)
+            .with_body(b"Internal Server Error")
+            .create_async()
+            .await;
+
+        let client = Client;
+        let url = format!("{}/retrieve_partial", server.url());
+        let result = client.download_partial(&job, &url).await;
+
+        mock.assert_async().await;
+        assert!(result.is_err(), "Expected error for client error status");
+        match result.unwrap_err() {
+            DownloadPartialError::RequestFailed(_) => {}
+            _ => panic!("Expected RequestFailed error"),
         }
     }
 }

--- a/src/services/endpoint.rs
+++ b/src/services/endpoint.rs
@@ -117,7 +117,11 @@ pub trait Endpoint {
 }
 
 /// Retrieve partial data (current state) from a job on the client
-pub async fn retrieve_partial<T>(job: &Job, config: &Config, target: T) -> Result<Vec<u8>, DownloadPartialError>
+pub async fn retrieve_partial<T>(
+    job: &Job,
+    config: &Config,
+    target: T,
+) -> Result<Vec<u8>, DownloadPartialError>
 where
     T: Endpoint,
 {
@@ -126,6 +130,7 @@ where
     } else {
         match config.get_download_url(&job.service) {
             Some(url) => {
+                // TODO: Remove this hack
                 // Replace the last path segment (e.g., "retrieve" or "download") with "retrieve_partial"
                 // This handles URLs like "http://client/retrieve" or "http://client/download"
                 let partial_url = if let Some(pos) = url.rfind('/') {
@@ -160,7 +165,11 @@ mod tests {
         async fn download(&self, _j: &Job, _url: &str) -> Result<Status, DownloadError> {
             Ok(Status::Completed)
         }
-        async fn download_partial(&self, _j: &Job, _url: &str) -> Result<Vec<u8>, DownloadPartialError> {
+        async fn download_partial(
+            &self,
+            _j: &Job,
+            _url: &str,
+        ) -> Result<Vec<u8>, DownloadPartialError> {
             Ok(b"partial data".to_vec())
         }
         async fn terminate(&self, _j: &Job, _url: &str) -> Result<(), TerminateError> {
@@ -175,7 +184,11 @@ mod tests {
         async fn download(&self, _j: &Job, _url: &str) -> Result<Status, DownloadError> {
             Err(DownloadError::NotFound)
         }
-        async fn download_partial(&self, _j: &Job, _url: &str) -> Result<Vec<u8>, DownloadPartialError> {
+        async fn download_partial(
+            &self,
+            _j: &Job,
+            _url: &str,
+        ) -> Result<Vec<u8>, DownloadPartialError> {
             Err(DownloadPartialError::NotFound)
         }
         async fn terminate(&self, _j: &Job, _url: &str) -> Result<(), TerminateError> {
@@ -292,7 +305,10 @@ mod tests {
         let config = make_config();
         let job = make_job(tempdir.path().to_str().unwrap(), "test", 0);
         let result = retrieve_partial(&job, &config, OkMockEndpoint).await;
-        assert!(matches!(result.unwrap_err(), DownloadPartialError::NotFound));
+        assert!(matches!(
+            result.unwrap_err(),
+            DownloadPartialError::NotFound
+        ));
     }
 
     #[tokio::test]
@@ -302,7 +318,10 @@ mod tests {
         let mut job = make_job(tempdir.path().to_str().unwrap(), "test", 1);
         job.dest_id = 0;
         let result = retrieve_partial(&job, &config, OkMockEndpoint).await;
-        assert!(matches!(result.unwrap_err(), DownloadPartialError::NotFound));
+        assert!(matches!(
+            result.unwrap_err(),
+            DownloadPartialError::NotFound
+        ));
     }
 
     #[tokio::test]
@@ -312,7 +331,10 @@ mod tests {
         let mut job = make_job(tempdir.path().to_str().unwrap(), "nonexistent", 1);
         job.dest_id = 42; // Set dest_id so it doesn't fail with NotFound first
         let result = retrieve_partial(&job, &config, OkMockEndpoint).await;
-        assert!(matches!(result.unwrap_err(), DownloadPartialError::InvalidService));
+        assert!(matches!(
+            result.unwrap_err(),
+            DownloadPartialError::InvalidService
+        ));
     }
 
     #[tokio::test]

--- a/src/services/endpoint.rs
+++ b/src/services/endpoint.rs
@@ -52,6 +52,18 @@ pub enum DownloadError {
 }
 
 #[derive(Debug, thiserror::Error)]
+pub enum DownloadPartialError {
+    #[error("Request failed: {0}")]
+    RequestFailed(#[from] reqwest::Error),
+    #[error("Failed to read response: {0}")]
+    ResponseReadFailed(reqwest::Error),
+    #[error("Not found")]
+    NotFound,
+    #[error("Invalid service")]
+    InvalidService,
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum TerminateError {
     #[error("generic")]
     GenericError,
@@ -100,7 +112,33 @@ where
 pub trait Endpoint {
     async fn upload(&self, j: &Job, url: &str) -> Result<u32, UploadError>;
     async fn download(&self, j: &Job, url: &str) -> Result<Status, DownloadError>;
+    async fn download_partial(&self, j: &Job, url: &str) -> Result<Vec<u8>, DownloadPartialError>;
     async fn terminate(&self, job_id: &Job, url: &str) -> Result<(), TerminateError>;
+}
+
+/// Retrieve partial data (current state) from a job on the client
+pub async fn retrieve_partial<T>(job: &Job, config: &Config, target: T) -> Result<Vec<u8>, DownloadPartialError>
+where
+    T: Endpoint,
+{
+    if job.id == 0 || job.dest_id == 0 {
+        Err(DownloadPartialError::NotFound)
+    } else {
+        match config.get_download_url(&job.service) {
+            Some(url) => {
+                // Replace the last path segment (e.g., "retrieve" or "download") with "retrieve_partial"
+                // This handles URLs like "http://client/retrieve" or "http://client/download"
+                let partial_url = if let Some(pos) = url.rfind('/') {
+                    format!("{}/retrieve_partial", &url[..pos])
+                } else {
+                    // If no slash, just append
+                    format!("{}/retrieve_partial", url)
+                };
+                Ok(target.download_partial(job, &partial_url).await?)
+            }
+            None => Err(DownloadPartialError::InvalidService),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -122,6 +160,9 @@ mod tests {
         async fn download(&self, _j: &Job, _url: &str) -> Result<Status, DownloadError> {
             Ok(Status::Completed)
         }
+        async fn download_partial(&self, _j: &Job, _url: &str) -> Result<Vec<u8>, DownloadPartialError> {
+            Ok(b"partial data".to_vec())
+        }
         async fn terminate(&self, _j: &Job, _url: &str) -> Result<(), TerminateError> {
             Ok(())
         }
@@ -133,6 +174,9 @@ mod tests {
         }
         async fn download(&self, _j: &Job, _url: &str) -> Result<Status, DownloadError> {
             Err(DownloadError::NotFound)
+        }
+        async fn download_partial(&self, _j: &Job, _url: &str) -> Result<Vec<u8>, DownloadPartialError> {
+            Err(DownloadPartialError::NotFound)
         }
         async fn terminate(&self, _j: &Job, _url: &str) -> Result<(), TerminateError> {
             Err(TerminateError::GenericError)
@@ -228,6 +272,56 @@ mod tests {
         let config = make_config();
         let job = make_job(tempdir.path().to_str().unwrap(), "test", 1);
         let result = retrieve(&job, &config, ErrMockEndpoint).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_valid_job() {
+        let tempdir = TempDir::new().unwrap();
+        let config = make_config();
+        let mut job = make_job(tempdir.path().to_str().unwrap(), "test", 1);
+        job.dest_id = 42; // Set dest_id so it doesn't fail with NotFound
+        let result = retrieve_partial(&job, &config, OkMockEndpoint).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), b"partial data");
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_job_id_zero() {
+        let tempdir = TempDir::new().unwrap();
+        let config = make_config();
+        let job = make_job(tempdir.path().to_str().unwrap(), "test", 0);
+        let result = retrieve_partial(&job, &config, OkMockEndpoint).await;
+        assert!(matches!(result.unwrap_err(), DownloadPartialError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_job_dest_id_zero() {
+        let tempdir = TempDir::new().unwrap();
+        let config = make_config();
+        let mut job = make_job(tempdir.path().to_str().unwrap(), "test", 1);
+        job.dest_id = 0;
+        let result = retrieve_partial(&job, &config, OkMockEndpoint).await;
+        assert!(matches!(result.unwrap_err(), DownloadPartialError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_invalid_service() {
+        let tempdir = TempDir::new().unwrap();
+        let config = make_config();
+        let mut job = make_job(tempdir.path().to_str().unwrap(), "nonexistent", 1);
+        job.dest_id = 42; // Set dest_id so it doesn't fail with NotFound first
+        let result = retrieve_partial(&job, &config, OkMockEndpoint).await;
+        assert!(matches!(result.unwrap_err(), DownloadPartialError::InvalidService));
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_propagates_error() {
+        let tempdir = TempDir::new().unwrap();
+        let config = make_config();
+        let mut job = make_job(tempdir.path().to_str().unwrap(), "test", 1);
+        job.dest_id = 42; // Set dest_id so it doesn't fail with NotFound
+        let result = retrieve_partial(&job, &config, ErrMockEndpoint).await;
         assert!(result.is_err());
     }
 

--- a/src/services/endpoint.rs
+++ b/src/services/endpoint.rs
@@ -61,6 +61,8 @@ pub enum DownloadPartialError {
     NotFound,
     #[error("Invalid service")]
     InvalidService,
+    #[error("Unexpected HTTP status: {0}")]
+    UnexpectedStatus(u16),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/services/endpoint.rs
+++ b/src/services/endpoint.rs
@@ -368,4 +368,19 @@ mod tests {
         let result = kill(&job, &config, OkMockEndpoint).await;
         assert!(result.is_err());
     }
+
+    #[tokio::test]
+    async fn test_retrieve_partial_url_without_trailing_slash() {
+        let tempdir = TempDir::new().unwrap();
+        let mut config = make_config();
+        // Set a download URL without trailing slash
+        if let Some(service) = config.services.get_mut("test") {
+            service.download_url = "http://example.com/download".to_string();
+        }
+        let mut job = make_job(tempdir.path().to_str().unwrap(), "test", 1);
+        job.dest_id = 42;
+        let result = retrieve_partial(&job, &config, OkMockEndpoint).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), b"partial data");
+    }
 }

--- a/src/services/endpoint.rs
+++ b/src/services/endpoint.rs
@@ -130,13 +130,15 @@ where
     } else {
         match config.get_download_url(&job.service) {
             Some(url) => {
-                // TODO: Remove this hack
                 // Replace the last path segment (e.g., "retrieve" or "download") with "retrieve_partial"
                 // This handles URLs like "http://client/retrieve" or "http://client/download"
                 let partial_url = if let Some(pos) = url.rfind('/') {
-                    format!("{}/retrieve_partial", &url[..pos])
+                    if pos + 1 < url.len() {
+                        format!("{}/retrieve_partial", &url[..pos + 1])
+                    } else {
+                        format!("{}retrieve_partial", url)
+                    }
                 } else {
-                    // If no slash, just append
                     format!("{}/retrieve_partial", url)
                 };
                 Ok(target.download_partial(job, &partial_url).await?)

--- a/src/services/endpoint.rs
+++ b/src/services/endpoint.rs
@@ -134,7 +134,7 @@ where
                 // This handles URLs like "http://client/retrieve" or "http://client/download"
                 let partial_url = if let Some(pos) = url.rfind('/') {
                     if pos + 1 < url.len() {
-                        format!("{}/retrieve_partial", &url[..pos + 1])
+                        format!("{}retrieve_partial", &url[..pos + 1])
                     } else {
                         format!("{}retrieve_partial", url)
                     }

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -89,8 +89,31 @@ pub(crate) fn write_directory_to_zip<W: std::io::Write + std::io::Seek>(
     let walkdir = WalkDir::new(src_dir);
     let it = walkdir.into_iter();
 
+    let canonical_source = std::fs::canonicalize(src_dir).map_err(|_| {
+        zip::result::ZipError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Failed to canonicalize source directory",
+        ))
+    })?;
+
     for entry in it.filter_map(|e| e.ok()) {
         let path = entry.path();
+        
+        // Check for path traversal: canonicalize the path and ensure it's within src_dir
+        let canonical_path = std::fs::canonicalize(path).map_err(|_| {
+            zip::result::ZipError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Failed to canonicalize path",
+            ))
+        })?;
+        
+        if !canonical_path.starts_with(&canonical_source) {
+            return Err(zip::result::ZipError::Io(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "Path traversal detected",
+            )));
+        }
+        
         if let Ok(name) = path.strip_prefix(src_dir) {
             // Skip the root directory itself
             if name.as_os_str().is_empty() {
@@ -685,18 +708,10 @@ mod tests {
         let src_dir = temp_dir.path().join("nonexistent");
         let zip_path = temp_dir.path().join("output.zip");
 
-        // When source doesn't exist, walkdir creates an empty iterator
-        // The zip will be created but will be empty (0 entries)
+        // When source doesn't exist, canonicalization fails
         let result = zip_directory(&src_dir, &zip_path);
 
-        // The function succeeds but creates an empty zip
-        assert!(result.is_ok());
-        assert!(zip_path.exists());
-
-        // Verify it's empty
-        let file = File::open(&zip_path).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        assert_eq!(archive.len(), 0);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -820,19 +835,11 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let src_dir = temp_dir.path().join("nonexistent");
 
-        // When source doesn't exist, walkdir creates an empty iterator
-        // The zip will be created but will be empty (0 entries)
+        // When source doesn't exist, canonicalization fails
         let result = zip_directory_to_bytes(&src_dir);
 
-        // The function succeeds but creates an empty zip
-        assert!(result.is_ok());
-        let bytes = result.unwrap();
-        assert!(!bytes.is_empty());
-
-        // Verify it's empty
-        let cursor = std::io::Cursor::new(bytes);
-        let archive = zip::ZipArchive::new(cursor).unwrap();
-        assert_eq!(archive.len(), 0);
+        // The function should fail for non-existent directory
+        assert!(result.is_err());
     }
 
     // ===== write_directory_to_zip tests ===== 
@@ -960,19 +967,10 @@ mod tests {
         let buffer = Vec::new();
         let zip = ZipWriter::new(std::io::Cursor::new(buffer));
 
-        // When source doesn't exist, walkdir creates an empty iterator
-        // The function should succeed and return an empty zip
+        // When source doesn't exist, canonicalization fails
         let result = write_directory_to_zip(&src_dir, zip);
 
-        assert!(result.is_ok());
-        let cursor = result.unwrap();
-        let bytes = cursor.into_inner();
-        assert!(!bytes.is_empty());
-
-        // Verify it's empty
-        let cursor = std::io::Cursor::new(bytes);
-        let archive = zip::ZipArchive::new(cursor).unwrap();
-        assert_eq!(archive.len(), 0);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -74,11 +74,12 @@ pub async fn save_file(
     Ok(())
 }
 
-pub fn zip_directory(src_dir: &PathBuf, dst_file: &PathBuf) -> zip::result::ZipResult<()> {
-    // Create the output file
-    let file = File::create(dst_file)?;
-    let mut zip = ZipWriter::new(file);
-
+/// Internal helper function to write directory contents to a ZipWriter
+/// Returns the writer after finishing the zip
+pub(crate) fn write_directory_to_zip<W: std::io::Write + std::io::Seek>(
+    src_dir: &PathBuf,
+    mut zip: ZipWriter<W>,
+) -> zip::result::ZipResult<W> {
     // Set options for the zip file with explicit type annotation
     let options: FileOptions<()> = FileOptions::default()
         .compression_method(zip::CompressionMethod::Deflated)
@@ -111,9 +112,9 @@ pub fn zip_directory(src_dir: &PathBuf, dst_file: &PathBuf) -> zip::result::ZipR
                 // Add file to the zip archive
                 zip.start_file(name_str, options)?;
                 let mut f = File::open(path)?;
-                let mut buffer = Vec::new();
-                f.read_to_end(&mut buffer)?;
-                zip.write_all(&buffer)?;
+                let mut file_buffer = Vec::new();
+                f.read_to_end(&mut file_buffer)?;
+                zip.write_all(&file_buffer)?;
             }
         } else {
             return Err(zip::result::ZipError::Io(io::Error::new(
@@ -123,8 +124,27 @@ pub fn zip_directory(src_dir: &PathBuf, dst_file: &PathBuf) -> zip::result::ZipR
         }
     }
 
-    zip.finish()?;
+    zip.finish()
+}
+
+pub fn zip_directory(src_dir: &PathBuf, dst_file: &PathBuf) -> zip::result::ZipResult<()> {
+    // Create the output file
+    let file = File::create(dst_file)?;
+    let zip = ZipWriter::new(file);
+
+    // write_directory_to_zip consumes the zip writer and returns the underlying writer
+    write_directory_to_zip(src_dir, zip)?;
     Ok(())
+}
+
+/// Zip a directory to a byte vector (in-memory)
+pub fn zip_directory_to_bytes(src_dir: &PathBuf) -> zip::result::ZipResult<Vec<u8>> {
+    let buffer = Vec::new();
+    let zip = ZipWriter::new(std::io::Cursor::new(buffer));
+
+    // write_directory_to_zip consumes the zip writer and returns the underlying Cursor
+    let cursor = write_directory_to_zip(src_dir, zip)?;
+    Ok(cursor.into_inner())
 }
 
 /// Validate a script for dangerous patterns before execution.
@@ -689,5 +709,301 @@ mod tests {
         let zip_path = PathBuf::from("/nonexistent/path/output.zip");
         let result = zip_directory(&src_dir, &zip_path);
         assert!(result.is_err());
+    }
+
+    // ===== zip_directory_to_bytes tests ===== 
+
+    #[test]
+    fn test_zip_directory_to_bytes_single_file() -> zip::result::ZipResult<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        // Create a single file
+        let file_path = src_dir.join("test.txt");
+        std::fs::write(&file_path, b"Hello, World!").unwrap();
+
+        // Zip it
+        let bytes = zip_directory_to_bytes(&src_dir)?;
+
+        // Verify we got data
+        assert!(!bytes.is_empty());
+
+        // Verify contents by unzipping
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor)?;
+        assert_eq!(archive.len(), 1);
+
+        let mut zipped_file = archive.by_name("test.txt")?;
+        let mut contents = String::new();
+        zipped_file.read_to_string(&mut contents)?;
+        assert_eq!(contents, "Hello, World!");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_zip_directory_to_bytes_multiple_files() -> zip::result::ZipResult<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        // Create multiple files
+        std::fs::write(src_dir.join("file1.txt"), b"Content 1").unwrap();
+        std::fs::write(src_dir.join("file2.txt"), b"Content 2").unwrap();
+        std::fs::write(src_dir.join("file3.txt"), b"Content 3").unwrap();
+
+        let bytes = zip_directory_to_bytes(&src_dir)?;
+
+        // Verify we got data
+        assert!(!bytes.is_empty());
+
+        // Verify contents
+        let cursor = std::io::Cursor::new(bytes);
+        let archive = zip::ZipArchive::new(cursor)?;
+        assert_eq!(archive.len(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_zip_directory_to_bytes_nested() -> zip::result::ZipResult<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        // Create nested directory structure
+        let nested = src_dir.join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("file.txt"), b"Nested content").unwrap();
+        std::fs::write(src_dir.join("root.txt"), b"Root content").unwrap();
+
+        let bytes = zip_directory_to_bytes(&src_dir)?;
+
+        // Verify we got data
+        assert!(!bytes.is_empty());
+
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor)?;
+
+        // Should have: nested/ (directory), nested/file.txt, root.txt
+        assert!(archive.len() >= 2);
+
+        // Verify nested file exists
+        let mut nested_file = archive.by_name("nested/file.txt")?;
+        let mut contents = String::new();
+        nested_file.read_to_string(&mut contents)?;
+        assert_eq!(contents, "Nested content");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_zip_directory_to_bytes_empty() -> zip::result::ZipResult<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        let bytes = zip_directory_to_bytes(&src_dir)?;
+
+        // Should create a valid but empty zip
+        assert!(!bytes.is_empty());
+        let cursor = std::io::Cursor::new(bytes);
+        let archive = zip::ZipArchive::new(cursor)?;
+        assert_eq!(archive.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_zip_directory_to_bytes_nonexistent_source() {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("nonexistent");
+
+        // When source doesn't exist, walkdir creates an empty iterator
+        // The zip will be created but will be empty (0 entries)
+        let result = zip_directory_to_bytes(&src_dir);
+
+        // The function succeeds but creates an empty zip
+        assert!(result.is_ok());
+        let bytes = result.unwrap();
+        assert!(!bytes.is_empty());
+
+        // Verify it's empty
+        let cursor = std::io::Cursor::new(bytes);
+        let archive = zip::ZipArchive::new(cursor).unwrap();
+        assert_eq!(archive.len(), 0);
+    }
+
+    // ===== write_directory_to_zip tests ===== 
+
+    #[test]
+    fn test_write_directory_to_zip_single_file() -> zip::result::ZipResult<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        // Create a single file
+        let file_path = src_dir.join("test.txt");
+        std::fs::write(&file_path, b"Hello, World!").unwrap();
+
+        // Create a buffer and zip writer
+        let buffer = Vec::new();
+        let zip = ZipWriter::new(std::io::Cursor::new(buffer));
+
+        // Call the helper function
+        let cursor = write_directory_to_zip(&src_dir, zip)?;
+        let bytes = cursor.into_inner();
+
+        // Verify we got data
+        assert!(!bytes.is_empty());
+
+        // Verify contents by unzipping
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor)?;
+        assert_eq!(archive.len(), 1);
+
+        let mut zipped_file = archive.by_name("test.txt")?;
+        let mut contents = String::new();
+        zipped_file.read_to_string(&mut contents)?;
+        assert_eq!(contents, "Hello, World!");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_directory_to_zip_multiple_files() -> zip::result::ZipResult<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        // Create multiple files
+        std::fs::write(src_dir.join("file1.txt"), b"Content 1").unwrap();
+        std::fs::write(src_dir.join("file2.txt"), b"Content 2").unwrap();
+
+        let buffer = Vec::new();
+        let zip = ZipWriter::new(std::io::Cursor::new(buffer));
+
+        let cursor = write_directory_to_zip(&src_dir, zip)?;
+        let bytes = cursor.into_inner();
+
+        assert!(!bytes.is_empty());
+
+        let cursor = std::io::Cursor::new(bytes);
+        let archive = zip::ZipArchive::new(cursor)?;
+        assert_eq!(archive.len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_directory_to_zip_nested() -> zip::result::ZipResult<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        // Create nested directory structure
+        let nested = src_dir.join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("file.txt"), b"Nested content").unwrap();
+        std::fs::write(src_dir.join("root.txt"), b"Root content").unwrap();
+
+        let buffer = Vec::new();
+        let zip = ZipWriter::new(std::io::Cursor::new(buffer));
+
+        let cursor = write_directory_to_zip(&src_dir, zip)?;
+        let bytes = cursor.into_inner();
+
+        assert!(!bytes.is_empty());
+
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor)?;
+
+        // Should have: nested/ (directory), nested/file.txt, root.txt
+        assert!(archive.len() >= 2);
+
+        // Verify nested file exists
+        let mut nested_file = archive.by_name("nested/file.txt")?;
+        let mut contents = String::new();
+        nested_file.read_to_string(&mut contents)?;
+        assert_eq!(contents, "Nested content");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_directory_to_zip_empty() -> zip::result::ZipResult<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        let buffer = Vec::new();
+        let zip = ZipWriter::new(std::io::Cursor::new(buffer));
+
+        let cursor = write_directory_to_zip(&src_dir, zip)?;
+        let bytes = cursor.into_inner();
+
+        assert!(!bytes.is_empty());
+
+        let cursor = std::io::Cursor::new(bytes);
+        let archive = zip::ZipArchive::new(cursor)?;
+        assert_eq!(archive.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_directory_to_zip_nonexistent_source() {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("nonexistent");
+
+        let buffer = Vec::new();
+        let zip = ZipWriter::new(std::io::Cursor::new(buffer));
+
+        // When source doesn't exist, walkdir creates an empty iterator
+        // The function should succeed and return an empty zip
+        let result = write_directory_to_zip(&src_dir, zip);
+
+        assert!(result.is_ok());
+        let cursor = result.unwrap();
+        let bytes = cursor.into_inner();
+        assert!(!bytes.is_empty());
+
+        // Verify it's empty
+        let cursor = std::io::Cursor::new(bytes);
+        let archive = zip::ZipArchive::new(cursor).unwrap();
+        assert_eq!(archive.len(), 0);
+    }
+
+    #[test]
+    fn test_write_directory_to_zip_to_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let src_dir = temp_dir.path().join("source");
+        std::fs::create_dir(&src_dir).unwrap();
+
+        // Create a test file
+        std::fs::write(src_dir.join("test.txt"), b"File content").unwrap();
+
+        // Create destination file
+        let dst_file = temp_dir.path().join("output.zip");
+
+        // Create file writer
+        let file = File::create(&dst_file).unwrap();
+        let zip = ZipWriter::new(file);
+
+        // Call the helper function
+        let _file = write_directory_to_zip(&src_dir, zip).unwrap();
+
+        // Verify the file was created and contains valid zip
+        assert!(dst_file.exists());
+
+        let file = File::open(&dst_file).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        assert_eq!(archive.len(), 1);
+
+        let mut zipped_file = archive.by_name("test.txt").unwrap();
+        let mut contents = String::new();
+        zipped_file.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "File content");
     }
 }

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -98,7 +98,7 @@ pub(crate) fn write_directory_to_zip<W: std::io::Write + std::io::Seek>(
 
     for entry in it.filter_map(|e| e.ok()) {
         let path = entry.path();
-        
+
         // Check for path traversal: canonicalize the path and ensure it's within src_dir
         let canonical_path = std::fs::canonicalize(path).map_err(|_| {
             zip::result::ZipError::Io(io::Error::new(
@@ -106,14 +106,23 @@ pub(crate) fn write_directory_to_zip<W: std::io::Write + std::io::Seek>(
                 "Failed to canonicalize path",
             ))
         })?;
-        
-        if !canonical_path.starts_with(&canonical_source) {
+
+        let relative = canonical_path
+            .strip_prefix(&canonical_source)
+            .map_err(|_| {
+                zip::result::ZipError::Io(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Path prefix mismatch",
+                ))
+            })?;
+
+        if relative.to_string_lossy().contains("..") {
             return Err(zip::result::ZipError::Io(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 "Path traversal detected",
             )));
         }
-        
+
         if let Ok(name) = path.strip_prefix(src_dir) {
             // Skip the root directory itself
             if name.as_os_str().is_empty() {
@@ -344,7 +353,10 @@ mod tests {
         let script_path = temp_dir.path().join("run.sh");
         fs::write(&script_path, b"#!/bin/bash\necho 'Hello, World!'\nexit 0\n").unwrap();
         let result = validate_script(&script_path);
-        assert!(matches!(result, Err(ClientError::MissingRequirement { .. })));
+        assert!(matches!(
+            result,
+            Err(ClientError::MissingRequirement { .. })
+        ));
     }
 
     #[test]
@@ -726,7 +738,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ===== zip_directory_to_bytes tests ===== 
+    // ===== zip_directory_to_bytes tests =====
 
     #[test]
     fn test_zip_directory_to_bytes_single_file() -> zip::result::ZipResult<()> {
@@ -842,7 +854,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ===== write_directory_to_zip tests ===== 
+    // ===== write_directory_to_zip tests =====
 
     #[test]
     fn test_write_directory_to_zip_single_file() -> zip::result::ZipResult<()> {


### PR DESCRIPTION
# ===autogenerated===
This pull request introduces a new "partial download" feature, allowing users to retrieve the current state of a job or payload as a zip file, even if the process is incomplete. This is useful for debugging or accessing intermediate results. The implementation includes new endpoints on both the client and server, updates to the OpenAPI documentation, and comprehensive tests to ensure correct behavior and error handling.

**Partial Download Feature Implementation**

* Added a new endpoint `retrieve_partial/{id}` to the client (`src/controllers/client.rs`) that returns a zip of the payload directory regardless of completion status. This uses the new `Payload::zip_partial()` method, which zips the directory contents directly to bytes. [[1]](diffhunk://#diff-ff254a9514dfdcd302c4ff8d7830e42a9119faeac5a3482bde9fb0077a401af5R113-R149) [[2]](diffhunk://#diff-ea52964fa711e1df904b31befb92e990b7ea1d3c4955eabde38fc17c20d20926R82-R89)
* Added a new endpoint `download_partial/{id}` to the server (`src/controllers/server.rs`) that proxies the partial download request to the client and returns the result, handling errors such as not found or invalid service configuration.
* Registered the new endpoints in the router and updated OpenAPI documentation accordingly (`src/routes/router.rs`). [[1]](diffhunk://#diff-90d4660ddab4f2e9f839e8ea72fbb40a7168035af10da2fc383c2dac5f0b2abcL2-R9) [[2]](diffhunk://#diff-90d4660ddab4f2e9f839e8ea72fbb40a7168035af10da2fc383c2dac5f0b2abcR36) [[3]](diffhunk://#diff-90d4660ddab4f2e9f839e8ea72fbb40a7168035af10da2fc383c2dac5f0b2abcR56) [[4]](diffhunk://#diff-90d4660ddab4f2e9f839e8ea72fbb40a7168035af10da2fc383c2dac5f0b2abcR85)
* Updated service and endpoint modules to support the new partial download error types and logic. [[1]](diffhunk://#diff-9009708a484929cc2c451c4c9af797144e7385293a693bfea1013bb0aafbac84L5-R5) [[2]](diffhunk://#diff-510aa5511d106881889d74a70448f6f2a409a53462bd9554220b492eed77377dR5-R6)

**Testing and Validation**

* Added comprehensive tests for the new endpoints, covering success cases, not found, invalid service, and error scenarios for both client and server. This ensures robust behavior and error handling for the partial download feature. [[1]](diffhunk://#diff-ff254a9514dfdcd302c4ff8d7830e42a9119faeac5a3482bde9fb0077a401af5R422-R564) [[2]](diffhunk://#diff-510aa5511d106881889d74a70448f6f2a409a53462bd9554220b492eed77377dR722-R882) [[3]](diffhunk://#diff-ea52964fa711e1df904b31befb92e990b7ea1d3c4955eabde38fc17c20d20926R315-R376) [[4]](diffhunk://#diff-ea52964fa711e1df904b31befb92e990b7ea1d3c4955eabde38fc17c20d20926R157)

**Summary of Most Important Changes**

*Partial Download Endpoints and Logic*
- Introduced `retrieve_partial/{id}` endpoint on the client to return a zip of the payload directory in any state, implemented via `Payload::zip_partial()`. [[1]](diffhunk://#diff-ff254a9514dfdcd302c4ff8d7830e42a9119faeac5a3482bde9fb0077a401af5R113-R149) [[2]](diffhunk://#diff-ea52964fa711e1df904b31befb92e990b7ea1d3c4955eabde38fc17c20d20926R82-R89)
- Introduced `download_partial/{id}` endpoint on the server to proxy partial download requests to the client, with full error handling and OpenAPI documentation. [[1]](diffhunk://#diff-510aa5511d106881889d74a70448f6f2a409a53462bd9554220b492eed77377dR72-R134) [[2]](diffhunk://#diff-510aa5511d106881889d74a70448f6f2a409a53462bd9554220b492eed77377dR5-R6)
- Registered new endpoints in the router and updated OpenAPI documentation for discoverability. [[1]](diffhunk://#diff-90d4660ddab4f2e9f839e8ea72fbb40a7168035af10da2fc383c2dac5f0b2abcL2-R9) [[2]](diffhunk://#diff-90d4660ddab4f2e9f839e8ea72fbb40a7168035af10da2fc383c2dac5f0b2abcR36) [[3]](diffhunk://#diff-90d4660ddab4f2e9f839e8ea72fbb40a7168035af10da2fc383c2dac5f0b2abcR56) [[4]](diffhunk://#diff-90d4660ddab4f2e9f839e8ea72fbb40a7168035af10da2fc383c2dac5f0b2abcR85)

*Testing and Error Handling*
- Added extensive tests for all new partial download scenarios on both client and server, including not found, invalid service, and zip errors. [[1]](diffhunk://#diff-ff254a9514dfdcd302c4ff8d7830e42a9119faeac5a3482bde9fb0077a401af5R422-R564) [[2]](diffhunk://#diff-510aa5511d106881889d74a70448f6f2a409a53462bd9554220b492eed77377dR722-R882) [[3]](diffhunk://#diff-ea52964fa711e1df904b31befb92e990b7ea1d3c4955eabde38fc17c20d20926R315-R376)
- Improved error typing and propagation in the endpoint and service layers to support new partial download logic.

These changes provide a robust mechanism for retrieving intermediate or incomplete job data, improving system transparency and debuggability.