### PR TITLE
handle kill failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "job-orchestrator"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 description = "Asynchronous job orchestrator for managing and routing payloads between services and computing resources with quota tracking"
 authors = ["Rodrigo V. Honorato <rvhonorato@protonmail.com>"]

--- a/src/models/payload_dao.rs
+++ b/src/models/payload_dao.rs
@@ -109,8 +109,16 @@ impl Payload {
         let status = std::process::Command::new("kill")
             .arg("-TERM")
             .arg(self.pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .status()?;
         if !status.success() {
+            // The process may have already exited (e.g. PID reused or job
+            // finished on its own). In that case there's nothing left to
+            // kill, so treat it as success rather than retrying forever.
+            if !is_pid_running(self.pid) {
+                return Ok(());
+            }
             return Err(std::io::Error::other(format!(
                 "kill failed for pid {}",
                 self.pid
@@ -286,13 +294,13 @@ mod test {
         // PID 0 should return Ok without doing anything
         assert!(p.kill().is_ok());
 
-        // Nonexistent PID should return Err since kill command fails
+        // Nonexistent PID is treated as already dead, so kill() is idempotent
         p.pid = 999999;
-        assert!(p.kill().is_err());
+        assert!(p.kill().is_ok());
 
         // Another nonexistent PID
         p.pid = 999998;
-        assert!(p.kill().is_err());
+        assert!(p.kill().is_ok());
 
         // Test successful kill of a real process
         // Note: We don't verify the process is actually dead because PIDs can be reused,

--- a/src/utils/sys.rs
+++ b/src/utils/sys.rs
@@ -4,6 +4,8 @@ pub fn is_pid_running(pid: u32) -> bool {
     Command::new("kill")
         .arg("-0")
         .arg(pid.to_string())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .status()
         .map(|s| s.success())
         .unwrap_or(false)


### PR DESCRIPTION
# ===autogenerated===

- Payload::kill() now redirects the spawned kill command's stdout/stderr to /dev/null, so its output no longer leaks into the orchestrator's logs.
- If kill -TERM <pid> fails, kill() now checks is_pid_running(pid) — if the process is already gone (e.g., it finished naturally or the PID was reused), termination is treated as success rather than an error.
- is_pid_running() (src/utils/sys.rs) similarly redirects the underlying kill -0 probe's stdout/stderr to /dev/null.

Why: Previously, when a job's PID no longer existed, kill() returned Err, so mark_as_killed() was never called and the job was never marked as terminated. Combined with the unredirected kill subprocess output, this produced an endless stream of kill: (PID): No such process lines in client logs as termination kept being retried.