### PR TITLE
fix: propagate file write errors in Payload::prepare instead of panicking

### DIFF
--- a/src/models/payload_dao.rs
+++ b/src/models/payload_dao.rs
@@ -62,9 +62,9 @@ impl Payload {
         fs::create_dir_all(&self.loc)?;
 
         // Dump data to this directory
-        self.input.iter_mut().for_each(|(filename, data)| {
-            fs::write(self.loc.join(filename), data).expect("Unable to write file")
-        });
+        self.input
+            .iter()
+            .try_for_each(|(filename, data)| fs::write(self.loc.join(filename), data))?;
 
         Ok(())
     }
@@ -196,6 +196,22 @@ mod test {
 
         let content = fs::read_to_string(expected_path).unwrap();
         assert_eq!(content, "Test data");
+    }
+
+    #[tokio::test]
+    async fn test_prepare_write_error_does_not_panic() {
+        let mut p = Payload::new();
+        p.id = 2;
+        // A filename containing a NUL byte is invalid on most filesystems,
+        // so `fs::write` will fail with an `Err` here. This must be
+        // propagated as an `Err` from `prepare`, not cause a panic.
+        p.add_input("bad\0name.txt".to_string(), b"Test data".to_vec());
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let data_path = temp_dir.path().to_str().unwrap();
+
+        let result = p.prepare(data_path);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Payload::prepare()` used `fs::write(...).expect("Unable to write file")` inside a `for_each`. Any I/O error (disk full, permission error, invalid filename) caused a panic. This is called synchronously from the `submit()` Axum handler, which has a `let Ok(_) = payload.prepare(...) else { return 500 }` branch that was effectively dead code for this failure mode — the panic happens first and aborts the connection without a clean response.

## Fix

Replaced `iter_mut().for_each(...).expect(...)` with `iter().try_for_each(...)?`, propagating the first I/O error through `prepare()`'s existing `Result<(), std::io::Error>` return type.

## Testing

Added `test_prepare_write_error_does_not_panic`, which uses a filename containing a NUL byte (invalid on most filesystems) to force `fs::write` to fail, and asserts `prepare()` returns `Err` rather than panicking.

`cargo test` (234 passed) and `cargo clippy -- -D warnings` both pass cleanly.

Fixes #57

---
Generated by Claude Code <Sonnet 4.6>.